### PR TITLE
Show terminal warning only when user did not enter arguments.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run `nvm` - no command - in terminal",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "console": "externalTerminal",
+            "program": "${workspaceFolder}/src/nvm.go",
+            "args": []
+        },
+        {
+            "name": "Run `nvm` - no command - in debug console",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/src/nvm.go",
+            "args": []
+        },
+        {
+            "name": "Run `nvm version`",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/src/nvm.go",
+            "args": [
+                "version"
+            ]
+        }
+    ]
+}

--- a/src/nvm.go
+++ b/src/nvm.go
@@ -70,9 +70,19 @@ func main() {
 	detail := ""
 	procarch := arch.Validate(env.arch)
 
-	if !isTerminal() {
-		alert("NVM for Windows should be run from a terminal such as CMD or PowerShell.", "Terminal Only")
-		os.Exit(0)
+	// When we don't have any args (the command `nvm` was run by itself):
+	//
+	// If it's not a terminal (i.e., clicked `nvm.exe`), pop up a warning;
+	// Otherwise, just show the help screen.
+	//
+	if len(args) < 2 {
+		if !isTerminal() {
+			alert("NVM for Windows should be run from a terminal such as CMD or PowerShell. If you are currently in a terminal, try running `nvm help`.", "Terminal Only")
+			os.Exit(0)
+		}
+
+		help()
+		return
 	}
 
 	// Capture any additional arguments


### PR DESCRIPTION
closes #1068

(doesn't fix the underlying terminal check, but limits the issue to users who didn't enter any `nvm` command)

Only check terminal when there are no arguments, because it's possible the user clicked the `.exe`. If there are arguments, assume the user knows what they're doing. Add some launch tasks in `.vscode` to demonstrate the difference. The warning now indicates that if you are in an unsupported terminal, to try running `nvm help` instead.

Feel free to remove `.vscode/launch.json` if you do not use VS Code. I used it to create an example of:

- Launching `nvm` without commands in debug console -- opens warning indicating `nvm` can only be run in a terminal
- Launching `nvm` in external console (like command prompt) -- prints normal help message in terminal
- Launching `nvm version` in debug console -- works normally