### PR TITLE
Fix npm install

### DIFF
--- a/src/nvm.go
+++ b/src/nvm.go
@@ -750,7 +750,7 @@ func install(version string, cpuarch string) {
 				defer os.RemoveAll(tempDir)
 
 				// Extract npm to the temp directory
-				err = file.Unzip(filepath.Join(tempDir, "npm-v"+npmv+".zip"), filepath.Join(tempDir, "nvm-npm"))
+				err = file.Unzip(filepath.Join(root, "temp", "npm-v"+npmv+".zip"), filepath.Join(tempDir, "nvm-npm"))
 				if err != nil {
 					status <- Status{Err: err}
 				}


### PR DESCRIPTION
There seems to have been a hiccup when refactoring the temp dir for NPM. See how [the tempDir variable](https://github.com/coreybutler/nvm-windows/commit/7de073ee16a76b924727af890eb5d284b3cff9c5#diff-c4d480f687d74c39997fc58e33d300c73cfb458321c2ab26c765772db70a679eL498) was modified -- the line to unzip then proceeds to unzip from the wrong location. This should solve https://github.com/coreybutler/nvm-windows/issues/1209 -- untested. Need to make sure that the rest of the flow works...