### PR TITLE
Correctly detect ARM64 Windows

### DIFF
--- a/src/arch/arch.go
+++ b/src/arch/arch.go
@@ -9,6 +9,19 @@ import (
 	"encoding/hex"
 )
 
+// NB: Because nvm itself is an Intel binary, on ARM64 it is running under 
+// emulation, extremely similar to WOW64. This means that PROCESSOR_ARCHITECTURE
+// will return x64, not arm64. For now, detect this case and return arm64
+func GetSystemArchitecture() string {
+  // If PROCESSOR_IDENTIFIER contains "ARM", return arm64
+  if strings.Contains(os.Getenv("PROCESSOR_IDENTIFIER"), "ARM") {
+    return "arm64"
+  }
+
+	// Fall back to PROCESSOR_ARCHITECTURE
+	return strings.ToLower(os.Getenv("PROCESSOR_ARCHITECTURE"))
+}
+
 func SearchBytesInFile( path string, match string, limit int) bool {
   // Transform to byte array the string
   toMatch, err := hex.DecodeString(match);
@@ -62,7 +75,7 @@ func Bit(path string) string {
 
 func Validate(str string) (string){
   if str == "" {
-    str = strings.ToLower(os.Getenv("PROCESSOR_ARCHITECTURE"))
+    str = GetSystemArchitecture()
   }
   if strings.Contains(str, "arm64") {
 	  return "arm64"

--- a/src/nvm.go
+++ b/src/nvm.go
@@ -63,7 +63,7 @@ var env = &Environment{
 	settings:        home,
 	root:            "",
 	symlink:         symlink,
-	arch:            strings.ToLower(os.Getenv("PROCESSOR_ARCHITECTURE")),
+	arch:            arch.GetSystemArchitecture(),
 	node_mirror:     "",
 	npm_mirror:      "",
 	proxy:           "none",
@@ -1281,11 +1281,12 @@ func validSymlink(symlinkpath string) error {
 }
 
 func useArchitecture(a string) {
-	if strings.ContainsAny("32", os.Getenv("PROCESSOR_ARCHITECTURE")) {
+	systemArch := arch.GetSystemArchitecture()
+	if strings.ContainsAny("32", systemArch) {
 		fmt.Println("This computer only supports 32-bit processing.")
 		return
 	}
-	if strings.Contains("arm64", strings.ToLower(os.Getenv("PROCESSOR_ARCHITECTURE"))) {
+	if strings.Contains("arm64", systemArch) {
 		fmt.Println("This computer only supports arm64-bit processing.")
 		return
 	}


### PR DESCRIPTION
ARM64 Windows is not currently correctly being detected because the process itself is being emulated as 64-bit Intel - this means that nvm gets a "simulated" set of environment variables, so PROCESSOR_ARCHITECTURE will be 64-bit Intel, not ARM64. Instead, make `nvm install` and friends work on ARM64 Windows similarly to other platforms