### PR TITLE
Enhance NVM_PATH input handling in install.cmd

### DIFF
--- a/assets/install.cmd
+++ b/assets/install.cmd
@@ -1,6 +1,10 @@
 @echo off
-set /P NVM_PATH="Enter the absolute path where the nvm-windows zip file is extracted/copied to: "
-set NVM_HOME=%NVM_PATH%
+
+if "%NVM_HOME%" == "" (
+  set /P NVM_PATH="Enter the absolute path where the nvm-windows zip file is extracted/copied to: "
+  set NVM_HOME=%NVM_PATH%
+)
+
 set NVM_SYMLINK=C:\Program Files\nodejs
 setx /M NVM_HOME "%NVM_HOME%"
 setx /M NVM_SYMLINK "%NVM_SYMLINK%"


### PR DESCRIPTION
Add check for NVM_HOME variable and prompt for input if empty

On extracting portable file, nvm install version fails if NVM_HOME variable is unset ("\settings.txt can't be opened"). Depending on whether or not the `install.cmd` is even called, this might not fix the problem (I wasn't able to verify that). 
Anyhow, I figured making the check conditional is probably good practice?