### PR TITLE
ci: support windows-arm64 again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,9 +101,24 @@ jobs:
       run: qgo --version
 
     - name: Build NVM for Windows
+      shell: pwsh
       run: |
         cd src
+
+        # amd64 -> nvm-64.exe (selected at install time by InstallX64)
+        $env:GOARCH = "amd64"
         qgo build --profile=release
+        Move-Item -Force "${{ github.workspace }}\bin\nvm.exe" "${{ github.workspace }}\bin\nvm-64.exe"
+
+        # arm64 -> nvm-arm64.exe (selected at install time by InstallARM64)
+        $env:GOARCH = "arm64"
+        qgo build --profile=release
+        Move-Item -Force "${{ github.workspace }}\bin\nvm.exe" "${{ github.workspace }}\bin\nvm-arm64.exe"
+
+        # 386 -> nvm.exe (fallback selected by InstallOtherArch)
+        $env:GOARCH = "386"
+        qgo build --profile=release
+
         echo ${{ github.workspace }}\bin
         dir ${{ github.workspace }}\bin
         cd ..\
@@ -124,9 +139,11 @@ jobs:
     - name: Apply icon to executable
       run: |
         $resourceHackerPath = "$env:USERPROFILE\resource_hacker\ResourceHacker.exe"
-        $exe = "${{ github.workspace }}\bin\nvm.exe"
         $iconFile = "${{ github.workspace }}\assets\nvm.ico"
-        & $resourceHackerPath -open $exe -save $exe -action add -res $iconFile -mask ICONGROUP,MAINICON
+        foreach ($name in @('nvm.exe', 'nvm-64.exe', 'nvm-arm64.exe')) {
+          $exe = "${{ github.workspace }}\bin\$name"
+          & $resourceHackerPath -open $exe -save $exe -action add -res $iconFile -mask ICONGROUP,MAINICON
+        }
 
     - name: Sign Executables
       uses: azure/trusted-signing-action@v0.5.0

--- a/nvm.iss
+++ b/nvm.iss
@@ -36,7 +36,7 @@ Compression=lzma
 SolidCompression=yes
 ChangesEnvironment=yes
 DisableProgramGroupPage=yes
-ArchitecturesInstallIn64BitMode=x64
+ArchitecturesInstallIn64BitMode=x64 arm64
 UninstallDisplayIcon={app}\{#MyIcon}
 
 ; Version information
@@ -54,7 +54,10 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked; OnlyBelowVersion: 0,6.1
 
 [Files]
-Source: "{#ProjectRoot}\bin\*"; DestDir: "{app}"; BeforeInstall: PreInstall; Flags: ignoreversion recursesubdirs createallsubdirs; Excludes: "{#ProjectRoot}\bin\install.cmd"
+Source: "{#ProjectRoot}\bin\*"; DestDir: "{app}"; BeforeInstall: PreInstall; Flags: ignoreversion recursesubdirs createallsubdirs; Excludes: "install.cmd,nvm.exe,nvm-64.exe,nvm-arm64.exe"
+Source: "{#ProjectRoot}\bin\nvm-arm64.exe"; DestDir: "{app}"; DestName: "nvm.exe"; Check: InstallARM64; Flags: solidbreak
+Source: "{#ProjectRoot}\bin\nvm-64.exe"; DestDir: "{app}"; DestName: "nvm.exe"; Check: InstallX64; Flags: solidbreak
+Source: "{#ProjectRoot}\bin\nvm.exe"; DestDir: "{app}"; DestName: "nvm.exe"; Check: InstallOtherArch
 
 [Icons]
 Name: "{group}\{#MyAppShortName}"; Filename: "{app}\{#MyAppExeName}"; IconFilename: "{#MyIcon}"
@@ -75,6 +78,21 @@ var
   EmailEdit: TEdit;
   EmailLabel: TLabel;
   PreText: TLabel;
+
+function InstallX64: Boolean;
+begin
+  Result := Is64BitInstallMode and (ProcessorArchitecture = paX64);
+end;
+
+function InstallARM64: Boolean;
+begin
+  Result := Is64BitInstallMode and (ProcessorArchitecture = paARM64);
+end;
+
+function InstallOtherArch: Boolean;
+begin
+  Result := not InstallX64 and not InstallARM64;
+end;
 
 function GetCurrentYear(Param: String): String;
 begin


### PR DESCRIPTION
## Summary

Re-enables Windows ARM64 support in the CI release pipeline and installer.

### Changes

**`.github/workflows/release.yml`**
- Switch the build step to PowerShell (`shell: pwsh`)
- Build three separate executables in sequence:
  - `nvm-64.exe` — compiled for `GOARCH=amd64`
  - `nvm-arm64.exe` — compiled for `GOARCH=arm64`
  - `nvm.exe` — compiled for `GOARCH=386` (fallback)
- Apply the NVM icon to all three executables (was previously only applied to `nvm.exe`)

**`nvm.iss`**
- Add `arm64` to `ArchitecturesInstallIn64BitMode` so the installer runs in 64-bit mode on ARM64 machines
- Ship all three binaries; use Inno Setup `Check:` functions to install the correct one as `nvm.exe` based on processor architecture:
  - `InstallARM64` — installs `nvm-arm64.exe` on ARM64 systems
  - `InstallX64` — installs `nvm-64.exe` on x64 systems
  - `InstallOtherArch` — installs the 32-bit `nvm.exe` as fallback
