### PR TITLE
fix: stop installation on download stream errors (#75)

### DIFF
--- a/src/web/web.go
+++ b/src/web/web.go
@@ -170,6 +170,7 @@ func Download(url string, target string, version string) bool {
 		_, err = io.Copy(output, response.Body)
 		if err != nil {
 			fmt.Printf("Error while downloading %s: %v\n", url, err)
+			return false
 		}
 	}
 


### PR DESCRIPTION
This PR fixes issue #75 where `nvm install` would incorrectly report a "Complete" status even if the network connection was lost or interrupted during the download process.

Currently, if `io.Copy` fails due to a connection reset or other stream errors, the error is printed but the function continues to return `true`, leading the installer to proceed as if the download were successful. This change ensures that any error during the download stream correctly returns `false`, halting the installation and triggering the necessary rollback.

## Changes

- Modified `src/web/web.go`: Added `return false` within the `io.Copy` error handling block in the `Download` function.


## Verification Results

### Unit Tests
I created a mock server test that simulates an unexpected connection reset (`unexpected EOF`) mid-download.
```powershell
PS C:\Users\sebaa\Desktop\GitHub\nvm-windows\src> go test -v ./web
=== RUN    TestDownloadFailure
Error while downloading [http://127.0.0.1:60493](http://127.0.0.1:60493): unexpected EOF
--- PASS: TestDownloadFailure (0.00s)
PASS
ok      nvm/web 0.652s